### PR TITLE
Fix for 16 port switches

### DIFF
--- a/psl_class.py
+++ b/psl_class.py
@@ -101,7 +101,7 @@ class ProSafeLinux:
     CMD_BROADCAST_BANDWIDTH = psl_typ.PslTypBandwidth(0x5800,
                  "broadcast_bandwidth")
     CMD_PORT_MIRROR = psl_typ.PslTypPortMirror(0x5c00, "port_mirror")
-    CMD_NUMBER_OF_PORTS = psl_typ.PslTypHex(0x6000, "number_of_ports")
+    CMD_NUMBER_OF_PORTS = psl_typ.PslTypInt(0x6000, "number_of_ports")
     CMD_IGMP_SNOOPING = psl_typ.PslTypIGMPSnooping(0x6800, "igmp_snooping")
     CMD_BLOCK_UNKNOWN_MULTICAST = psl_typ.PslTypBoolean(
                                               0x6c00, "block_unknown_multicast")


### PR DESCRIPTION
I have a GS116Ev2 which reports 10 ports (apparently it's in hexadecimal) and crashes when it tries to decode the `PslTypPortMirror` part due to an extra byte present for the next "octet" of ports.

This PR tries to mitigate this by
* reporting the number of ports as an integer
* taking the extra byte into account for port mirroring

Note that only _decoding_ was tested and the mirroring part still looks like a python dictionary; for example: if I mirror both ports 2 and 15 to 1 (via the webinterface), it looks like this:
`{'dst_port': 1, 'fixme': 0, 'src_ports': [2, 15]}`

Also note that I'm not fluent in Python; there might be better ways to decode either 3 or 4 bytes depending on the data provided by the switch.